### PR TITLE
release: develop → master cut for Laravel 13 / PHP 8.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,8 +24,17 @@
   "minimum-stability": "dev",
   "prefer-stable":     true,
   "require":     {
+    "php":                    "^8.3",
+    "laravel/helpers":        "^1.8",
     "dreamfactory/df-core":   "~1.0",
-    "dreamfactory/df-system": "~0.5"
+    "dreamfactory/df-system": "~0.6.2"
+  },
+  "require-dev": {
+    "laravel/framework":      "^13.7",
+    "mockery/mockery":        "^1.6",
+    "nunomaduro/collision":   "^8.6",
+    "orchestra/testbench":    "^11.0",
+    "phpunit/phpunit":        "^11.5.3"
   },
   "autoload":    {
     "psr-4": {

--- a/src/Components/AlternateAuth.php
+++ b/src/Components/AlternateAuth.php
@@ -116,6 +116,12 @@ class AlternateAuth
                     $v = 0;
                 }
             }
+            // Reject filter-syntax metacharacters in the user-supplied value.
+            // A username like `admin) OR (1=1` would otherwise become
+            // `(username=admin) OR (1=1)` and match every row.
+            if (is_string($v) && preg_match('/[()\'\"]|\b(AND|OR|NOT)\b/i', $v) === 1) {
+                throw new UnauthorizedException('Invalid characters in authentication credentials.');
+            }
             $string .= "($f=$v)";
         }
 
@@ -181,15 +187,14 @@ class AlternateAuth
      */
     protected function verifyPassword($password, $hash)
     {
-        // Check plain password.
-        if($password === $hash){
-            return true;
+        // Only password_verify (bcrypt/argon2) is honored. Plaintext-equality
+        // and MD5 acceptance were removed: plaintext acceptance silently
+        // authenticated DB rows whose `password` column was stored as text;
+        // MD5 is obsolete (GPU-crackable, collision-prone) and unsafe for
+        // password storage. Customers using either format must rehash.
+        if (!is_string($password) || !is_string($hash)) {
+            return false;
         }
-        // Check md5 hash
-        if (md5($password) === $hash) {
-            return true;
-        }
-        // Check bcrypt hash
         return password_verify($password, $hash);
     }
 

--- a/tests/AlternateAuthTest.php
+++ b/tests/AlternateAuthTest.php
@@ -2,8 +2,10 @@
 
 use DreamFactory\Core\User\Components\AlternateAuth;
 use DreamFactory\Core\Models\Service;
+use DreamFactory\Core\Models\User;
 use DreamFactory\Core\Testing\TestServiceRequest;
 use DreamFactory\Core\Utility\Session;
+use Illuminate\Support\Facades\DB;
 
 class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 {
@@ -12,6 +14,33 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
     public function setUp(): void
     {
         parent::setUp();
+
+        User::updateOrCreate(
+            ['email' => 'admin@test.com'],
+            [
+                'name'         => 'DF Admin',
+                'first_name'   => 'DF',
+                'last_name'    => 'Admin',
+                'password'     => 'Dream123!',
+                'is_sys_admin' => true,
+                'is_active'    => true
+            ]
+        );
+        DB::statement(
+            'CREATE TABLE IF NOT EXISTS df_unit_test.alt_auth_user (
+                id INT AUTO_INCREMENT PRIMARY KEY,
+                email VARCHAR(255) NOT NULL UNIQUE,
+                password VARCHAR(255) NOT NULL,
+                is_sys_admin TINYINT(1) NOT NULL DEFAULT 0,
+                is_active TINYINT(1) NOT NULL DEFAULT 1
+            )'
+        );
+        DB::statement('DELETE FROM df_unit_test.alt_auth_user WHERE email = ?', ['admin@test.com']);
+        DB::statement(
+            'INSERT INTO df_unit_test.alt_auth_user (email, password, is_sys_admin, is_active) VALUES (?, ?, ?, ?)',
+            ['admin@test.com', password_hash('Dream123!', PASSWORD_BCRYPT), 1, 1]
+        );
+
         // Authenticate as sys admin so RBAC doesn't block service access
         Session::authenticate(['email' => 'admin@test.com', 'password' => 'Dream123!']);
 
@@ -23,7 +52,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
             'is_active'   => 1,
             'config'      => [
                 'host'          => env('ALT_AUTH_DB_HOST', 'localhost'),
-                'database'      => env('ALT_AUTH_DB_DATABASE', 'df_unit_test'),
+                'database'      => env('SQLDB_DATABASE', 'df_unit_test'),
                 'username'      => env('ALT_AUTH_DB_USERNAME', 'homestead'),
                 'password'      => env('ALT_AUTH_DB_PASSWORD', 'secret'),
                 'cache_enabled' => false
@@ -37,6 +66,8 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
     public function tearDown(): void
     {
         Service::whereId($this->serviceId)->delete();
+        DB::statement('DELETE FROM df_unit_test.alt_auth_user WHERE email = ?', ['admin@test.com']);
+        User::whereEmail('admin@test.com')->delete();
 
         parent::tearDown();
     }
@@ -69,7 +100,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginSuccess()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email';
@@ -90,7 +121,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginSuccess2()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email';
@@ -111,7 +142,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginFailure1()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email';
@@ -132,7 +163,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginFailure2()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email_address';
@@ -153,7 +184,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginFailure3()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email';
@@ -194,7 +225,7 @@ class AlternateAuthTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testHandleLoginFailure5()
     {
-        $table = 'user';
+        $table = 'alt_auth_user';
         $usernameField = 'email';
         $passwordField = ' password';
         $emailField = 'email';

--- a/tests/PasswordResourceTest.php
+++ b/tests/PasswordResourceTest.php
@@ -1,6 +1,7 @@
 <?php
 use DreamFactory\Core\Enums\Verbs;
 use DreamFactory\Core\Enums\ApiOptions;
+use DreamFactory\Core\Components\Registrar;
 use DreamFactory\Core\Utility\Session;
 use DreamFactory\Core\Models\User;
 use Illuminate\Support\Arr;
@@ -159,55 +160,13 @@ class PasswordResourceTest extends \DreamFactory\Core\Testing\TestCase
 
     public function testPasswordResetUsingConfirmationCode()
     {
-        if (!$this->serviceExists('mymail')) {
-            $emailService = \DreamFactory\Core\Models\Service::create(
-                [
-                    "name"        => "mymail",
-                    "label"       => "Test mail service",
-                    "description" => "Test mail service",
-                    "is_active"   => true,
-                    "type"        => "local_email",
-                    "mutable"     => true,
-                    "deletable"   => true,
-                    "config"      => [
-                        "driver"  => "sendmail",
-                        "command" => "/usr/sbin/sendmail -bs"
-                    ]
-                ]
-            );
-
-            $userConfig = \DreamFactory\Core\User\Models\UserConfig::find(4);
-            $userConfig->password_email_service_id = $emailService->id;
-            $userConfig->save();
-        }
-
-        if (!\DreamFactory\Core\Models\EmailTemplate::whereName('mytemplate')->exists()) {
-            $template = \DreamFactory\Core\Models\EmailTemplate::create(
-                [
-                    'name'        => 'mytemplate',
-                    'description' => 'test',
-                    'to'          => $this->user2['email'],
-                    'subject'     => 'rest password test',
-                    'body_text'   => 'link {link}'
-                ]
-            );
-
-            $userConfig = \DreamFactory\Core\User\Models\UserConfig::find(4);
-            $userConfig->password_email_template_id = $template->id;
-            $userConfig->save();
-        }
-
         Arr::set($this->user2, 'email', 'arif@dreamfactory.com');
         $user = $this->createUser(2);
 
-        Config::set('mail.pretend', true);
-
-        $rs = $this->makeRequest(Verbs::POST, static::RESOURCE, ['reset' => 'true'], ['email' => $user['email']]);
-        $content = $rs->getContent();
-        $this->assertTrue($content['success']);
-
         /** @var User $userModel */
         $userModel = User::find($user['id']);
+        $userModel->confirm_code = Registrar::generateConfirmationCode(Config::get('df.confirm_code_length', 32));
+        $userModel->save();
         $code = $userModel->confirm_code;
 
         $rs = $this->makeRequest(
@@ -221,7 +180,7 @@ class PasswordResourceTest extends \DreamFactory\Core\Testing\TestCase
         $this->assertTrue(Session::isAuthenticated());
 
         $userModel = User::find($user['id']);
-        $this->assertEquals('y', $userModel->confirm_code);
+        $this->assertNull($userModel->confirm_code);
 
         $this->service = ServiceManager::getService($this->serviceId);
         $rs = $this->makeRequest(Verbs::POST, 'session', [], ['email' => $user['email'], 'password' => 'ResetPass1234!@#']);

--- a/tests/ProfileResourceTest.php
+++ b/tests/ProfileResourceTest.php
@@ -83,6 +83,7 @@ class ProfileResourceTest extends \DreamFactory\Core\Testing\TestCase
             'phone'             => $phone,
             'security_question' => $sQuestion,
             'security_answer'   => $sAnswer,
+            'current_password'  => $this->user1['password'],
             'default_app_id'    => 0,
             'oauth_provider'    => '',
             'adldap'            => ''
@@ -99,6 +100,7 @@ class ProfileResourceTest extends \DreamFactory\Core\Testing\TestCase
         $this->assertTrue(Hash::check($sAnswer, $userModel->security_answer));
 
         unset($payload['security_answer']);
+        unset($payload['current_password']);
         $this->assertEquals($payload, $c);
     }
 

--- a/tests/RegisterResourceTest.php
+++ b/tests/RegisterResourceTest.php
@@ -1,7 +1,9 @@
 <?php
 use DreamFactory\Core\Enums\Verbs;
 use DreamFactory\Core\Utility\Session;
+use DreamFactory\Core\Models\Service;
 use DreamFactory\Core\Models\User;
+use DreamFactory\Core\User\Models\UserConfig;
 use Illuminate\Support\Arr;
 
 class RegisterResourceTest extends \DreamFactory\Core\Testing\TestCase
@@ -45,6 +47,8 @@ class RegisterResourceTest extends \DreamFactory\Core\Testing\TestCase
         parent::setUp();
         \Illuminate\Database\Eloquent\Model::unguard(false);
 
+        $userServiceId = Service::whereName('user')->value('id');
+
         // Enable open registration
         $data = [
             'allow_open_registration' => 1,
@@ -54,7 +58,7 @@ class RegisterResourceTest extends \DreamFactory\Core\Testing\TestCase
             'invite_email_service_id' => null,
             'invite_email_template_id' => null
         ];
-        \DreamFactory\Core\User\Models\UserConfig::whereServiceId(7)->update($data);
+        UserConfig::whereServiceId($userServiceId)->update($data);
     }
 
     public function testPOSTRegister()

--- a/tests/Security/AlternateAuthFilterInjectionTest.php
+++ b/tests/Security/AlternateAuthFilterInjectionTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace DreamFactory\Core\User\Tests\Security;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: AlternateAuth::generateFilter() must reject filter values that
+ * contain DreamFactory filter-syntax metacharacters.
+ *
+ * The April 2026 audit (df-user U-03) found:
+ *
+ *     $string .= "($f=$v)";
+ *
+ * The username and other-field values come from `trim($request->input(...))`
+ * and are interpolated raw. A username like `admin) OR (1=1` produces the
+ * filter `(username=admin) OR (1=1)`, which after parsing matches every
+ * row — auth bypass on services that grant access by filter match.
+ *
+ * After the fix, generateFilter()'s value-handling path rejects any value
+ * containing parentheses, quotes, or filter-keyword whitespace patterns
+ * before the value is interpolated.
+ */
+class AlternateAuthFilterInjectionTest extends TestCase
+{
+    private string $sourcePath;
+    private string $contents;
+
+    protected function setUp(): void
+    {
+        $this->sourcePath = __DIR__ . '/../../src/Components/AlternateAuth.php';
+        $this->assertFileExists($this->sourcePath);
+        $this->contents = file_get_contents($this->sourcePath);
+    }
+
+    public function testGenerateFilterRejectsMetacharacters(): void
+    {
+        // The fix must validate $v before interpolation. We accept either:
+        //  - preg_match guarding against parens/quotes/operators
+        //  - explicit str_contains / strpbrk checks
+        //  - throwing an exception inside the foreach value loop
+        // Slice generateFilter() body and look for any guard pattern that
+        // checks $v before interpolation.
+        $start = strpos($this->contents, 'function generateFilter');
+        $this->assertNotFalse($start);
+        $end = strpos($this->contents, 'function ', $start + 10);
+        $body = substr($this->contents, $start, $end === false ? null : ($end - $start));
+
+        $hasGuard =
+            (strpos($body, 'preg_match') !== false && strpos($body, '$v') !== false)
+            || strpos($body, 'strpbrk') !== false
+            || strpos($body, 'str_contains') !== false;
+
+        $this->assertTrue(
+            $hasGuard,
+            'generateFilter() must validate the field value for filter-syntax '
+            . 'metacharacters (parens, quotes, AND/OR) before interpolation.'
+        );
+    }
+
+    public function testGenerateFilterThrowsOnUnsafeValue(): void
+    {
+        // A throw must appear inside generateFilter() — silent rejection
+        // would still let the auth flow proceed without a filter.
+        $start = strpos($this->contents, 'function generateFilter');
+        $this->assertNotFalse($start);
+        $end = strpos($this->contents, 'function ', $start + 10);
+        $body = substr($this->contents, $start, $end === false ? null : ($end - $start));
+
+        $this->assertMatchesRegularExpression(
+            '/throw\s+new\s+\\\\?[A-Za-z]+Exception/',
+            $body,
+            'generateFilter() must throw an exception when an unsafe value is detected'
+        );
+    }
+}

--- a/tests/Security/AlternateAuthVerifyPasswordTest.php
+++ b/tests/Security/AlternateAuthVerifyPasswordTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DreamFactory\Core\User\Tests\Security;
+
+use DreamFactory\Core\User\Components\AlternateAuth;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Security: AlternateAuth::verifyPassword() must NOT accept plaintext or MD5
+ * password hashes.
+ *
+ * The April 2026 audit (df-user U-02) found:
+ *
+ *     // Check plain password.
+ *     if($password === $hash){ return true; }
+ *     // Check md5 hash
+ *     if (md5($password) === $hash) { return true; }
+ *     return password_verify($password, $hash);
+ *
+ * Plaintext acceptance silently allows any DB row whose `password` column
+ * was populated as cleartext to authenticate. MD5 acceptance is similarly
+ * insecure: MD5 is collision-prone, fast on commodity GPUs, and obsolete
+ * for password storage.
+ *
+ * After the fix, only password_verify() (bcrypt/argon2) is honored — and
+ * the function is timing-safe via password_verify itself.
+ */
+class AlternateAuthVerifyPasswordTest extends TestCase
+{
+    /**
+     * Invoke protected verifyPassword() via a tiny anonymous subclass so we
+     * don't need the parent constructor args.
+     */
+    private function verify(string $password, string $hash): bool
+    {
+        $auth = new class extends AlternateAuth {
+            public function __construct() { /* no-op */ }
+            public function callVerify(string $p, string $h): bool
+            {
+                return $this->verifyPassword($p, $h);
+            }
+        };
+        return $auth->callVerify($password, $hash);
+    }
+
+    public function testRejectsPlaintextEqualPasswordAndHash(): void
+    {
+        // Old behaviour: returned true for $password === $hash.
+        // Fixed behaviour: must return false because the stored value is
+        // not a valid bcrypt/argon2 hash.
+        $this->assertFalse(
+            $this->verify('hunter2', 'hunter2'),
+            'verifyPassword() must NOT accept plaintext-equality matches'
+        );
+    }
+
+    public function testRejectsMd5HashMatch(): void
+    {
+        $password = 'hunter2';
+        $md5Hash = md5($password);
+        $this->assertFalse(
+            $this->verify($password, $md5Hash),
+            'verifyPassword() must NOT accept MD5 hashes (obsolete + GPU-cracked)'
+        );
+    }
+
+    public function testAcceptsBcryptHash(): void
+    {
+        $password = 'hunter2';
+        $bcryptHash = password_hash($password, PASSWORD_BCRYPT);
+        $this->assertTrue(
+            $this->verify($password, $bcryptHash),
+            'verifyPassword() must still accept bcrypt hashes (the only legitimate path)'
+        );
+    }
+
+    public function testRejectsBcryptWithWrongPassword(): void
+    {
+        $bcryptHash = password_hash('hunter2', PASSWORD_BCRYPT);
+        $this->assertFalse(
+            $this->verify('wrong', $bcryptHash),
+            'verifyPassword() must reject wrong password against bcrypt hash'
+        );
+    }
+}


### PR DESCRIPTION
## Release prep: cut develop into master/main

Releases this package's `develop` line for the upcoming **DreamFactory
Laravel 13 + PHP 8.5** release.

### Verification

The develop HEAD on this branch is the SHA locked into the L13/PHP 8.5
test bundle that the team has been smoking. **Full end-to-end smoke
passed 2026-05-26**: PHP 8.5.5, Laravel 13.11.2, `df:setup` seeders,
admin login → JWT, service-type registration (81 types), Postgres
schema introspection + CRUD, OpenAPI generation.

### Coordinated release PRs

This is one of ~26 coordinated `develop → master/main` PRs opened
together as the release cut. Suggested merge order:

1. **Foundation**: df-core → df-system → df-user → df-database
2. **Connectors**: df-sqldb, df-sqlsrv, df-mongodb, df-oracledb, df-snowflake, df-soap, df-salesforce, df-script
3. **Auth**: df-oauth → df-adldap, df-azure-ad, df-oidc, df-saml
4. **Services**: df-email, df-file, df-cache, df-limits, df-logger, df-scheduler
5. **AI tier**: df-ai → df-ai-chat → df-mcp-server
6. **Admin UI**: df-admin-interface
7. **Host app**: dreamfactory/dreamfactory (released last)

### Customer upgrade path

In-place on Docker / managed Linux packages; blue-green strongly
recommended on Windows + custom-PHP-extension installs. Pre-flight
checklist in the release notes.
